### PR TITLE
Feature/fix null values

### DIFF
--- a/src/couchbase-plugin.android.ts
+++ b/src/couchbase-plugin.android.ts
@@ -163,7 +163,6 @@ export class Couchbase extends Common {
 
     private serializeObject(item, object, key) {
         if (item === null) {
-            object.setValue(key, item);
             return;
         }
 
@@ -188,7 +187,7 @@ export class Couchbase extends Common {
                     const obj = item[itemKey];
                     this.serializeObject(obj, nativeObject, itemKey);
                 });
-                object.setDictionary(key, object);
+                object.setDictionary(key, nativeObject);
                 break;
             case 'number':
                 if (item <= Math.pow(2, 31) - 1) {
@@ -207,7 +206,6 @@ export class Couchbase extends Common {
 
     private serializeArray(item, array: any) {
         if (item === null) {
-            array.addValue(item);
             return
         }
 
@@ -251,7 +249,6 @@ export class Couchbase extends Common {
 
     private serialize(item, doc: any, key) {
         if (item === null) {
-            doc.setValue(key, item);
             return;
         }
 

--- a/src/couchbase-plugin.android.ts
+++ b/src/couchbase-plugin.android.ts
@@ -49,6 +49,7 @@ export class Couchbase extends Common {
             this.android.save(doc);
             return doc.getId();
         } catch (e) {
+            console.error(e.message);
             return null;
         }
     }
@@ -161,6 +162,11 @@ export class Couchbase extends Common {
     }
 
     private serializeObject(item, object, key) {
+        if (item === null) {
+            object.setValue(key, item);
+            return;
+        }
+
         switch (typeof item) {
             case 'object':
                 if (item instanceof Date) {
@@ -200,6 +206,11 @@ export class Couchbase extends Common {
     }
 
     private serializeArray(item, array: any) {
+        if (item === null) {
+            array.addValue(item);
+            return
+        }
+
         switch (typeof item) {
             case 'object':
                 if (item instanceof Date) {
@@ -239,6 +250,11 @@ export class Couchbase extends Common {
     }
 
     private serialize(item, doc: any, key) {
+        if (item === null) {
+            doc.setValue(key, item);
+            return;
+        }
+
         switch (typeof item) {
             case 'object':
                 if (item instanceof Date) {

--- a/src/couchbase-plugin.ios.ts
+++ b/src/couchbase-plugin.ios.ts
@@ -57,6 +57,10 @@ export class Couchbase extends Common {
     }
 
     private serializeObject(item, object: any, key) {
+        if (item === null) {
+            return;
+        }
+
         switch (typeof item) {
             case 'object':
                 if (item instanceof Date) {
@@ -78,7 +82,7 @@ export class Couchbase extends Common {
                     const obj = item[itemKey];
                     this.serializeObject(obj, nativeObject, itemKey);
                 });
-                object.setDictionaryForKey(object, key);
+                object.setDictionaryForKey(nativeObject, key);
                 break;
             case 'number':
                 object.setIntegerForKey(item, key);
@@ -92,6 +96,10 @@ export class Couchbase extends Common {
     }
 
     private serializeArray(item, array: any) {
+        if (item === null) {
+            return;
+        }
+
         switch (typeof item) {
             case 'object':
                 if (item instanceof Date) {
@@ -127,6 +135,10 @@ export class Couchbase extends Common {
     }
 
     private serialize(item, doc: any, key) {
+        if (item === null) {
+            return;
+        }
+
         switch (typeof item) {
             case 'object':
                 if (item instanceof Date) {


### PR DESCRIPTION
This PR fixes objects that contain null values. Normally null values would be seen as an type object, and then it would fail on something in the case 'object'. This change will not save the null values, I'm not sure whether this is a correct solution. I could not figure out how to properly save null values. Since we decode the objects back into typescript classes, we don't need the null values.

I also fixed a bug with embedded objects.
The code `object.setDictionary(key, object);` would create a reference to itself, this does not work, I figured it was a programming error, so I changed it to `object.setDictionary(key, nativeObject);`