### PR TITLE
Add support for long/float/double

### DIFF
--- a/src/couchbase-plugin.android.ts
+++ b/src/couchbase-plugin.android.ts
@@ -200,10 +200,18 @@ export class Couchbase extends Common {
                 object.setDictionary(key, nativeObject);
                 break;
             case 'number':
-                if (item <= Math.pow(2, 31) - 1) {
-                    object.setInt(key, item);
+                if (this.numberIs64Bit(item)) {
+                    if (this.numberHasDecimals(item)) {
+                        object.setDouble(key, item);
+                    } else {
+                        object.setLong(key, item);
+                    }
                 } else {
-                    object.setLong(key, item);
+                    if (this.numberHasDecimals(item)) {
+                        object.setFloat(key, item);
+                    } else {
+                        object.setInt(key, item);
+                    }
                 }
                 break;
             case 'boolean':
@@ -243,10 +251,18 @@ export class Couchbase extends Common {
                 array.addDictionary(object);
                 break;
             case 'number':
-                if (item <= Math.pow(2, 31) - 1) {
-                    array.addInt(item);
+                if (this.numberIs64Bit(item)) {
+                    if (this.numberHasDecimals(item)) {
+                        array.addDouble(item);
+                    } else {
+                        array.addLong(item);
+                    }
                 } else {
-                    array.addLong(item);
+                    if (this.numberHasDecimals(item)) {
+                        array.addFloat(item);
+                    } else {
+                        array.addInt(item);
+                    }
                 }
                 break;
             case 'boolean':
@@ -286,10 +302,18 @@ export class Couchbase extends Common {
                 doc.setDictionary(key, object);
                 break;
             case 'number':
-                if (item <= Math.pow(2, 31) - 1) {
-                    doc.setInt(key, item);
+                if (this.numberIs64Bit(item)) {
+                    if (this.numberHasDecimals(item)) {
+                        doc.setDouble(key, item);
+                    } else {
+                        doc.setLong(key, item);
+                    }
                 } else {
-                    doc.setLong(key, item);
+                    if (this.numberHasDecimals(item)) {
+                        doc.setFloat(key, item);
+                    } else {
+                        doc.setInt(key, item);
+                    }
                 }
                 break;
             case 'boolean':
@@ -298,6 +322,14 @@ export class Couchbase extends Common {
             default:
                 doc.setValue(key, item);
         }
+    }
+
+    numberHasDecimals(item: number) {
+        return !(item % 1 === 0);
+    }
+
+    numberIs64Bit(item: number) {
+        return item < -Math.pow(2, 31) + 1 || item > Math.pow(2, 31) - 1;
     }
 
     deleteDocument(documentId: string) {

--- a/src/couchbase-plugin.ios.ts
+++ b/src/couchbase-plugin.ios.ts
@@ -90,7 +90,19 @@ export class Couchbase extends Common {
                 object.setDictionaryForKey(nativeObject, key);
                 break;
             case 'number':
-                object.setIntegerForKey(item, key);
+                if (this.numberIs64Bit(item)) {
+                    if (this.numberHasDecimals(item)) {
+                        object.setDoubleForKey(item, key);
+                    } else {
+                        object.setLongLongForKey(item, key);
+                    }
+                } else {
+                    if (this.numberHasDecimals(item)) {
+                        object.setFloatForKey(item, key);
+                    } else {
+                        object.setIntegerForKey(item, key);
+                    }
+                }
                 break;
             case 'boolean':
                 object.setBooleanForKey(item, key);
@@ -129,7 +141,19 @@ export class Couchbase extends Common {
                 array.addDictionary(object);
                 break;
             case 'number':
-                array.addInteger(item);
+                if (this.numberIs64Bit(item)) {
+                    if (this.numberHasDecimals(item)) {
+                        array.addDouble(item);
+                    } else {
+                        array.addLongLong(item);
+                    }
+                } else {
+                    if (this.numberHasDecimals(item)) {
+                        array.addFloat(item);
+                    } else {
+                        array.addInteger(item);
+                    }
+                }
                 break;
             case 'boolean':
                 array.addBoolean(item);
@@ -168,7 +192,19 @@ export class Couchbase extends Common {
                 doc.setDictionaryForKey(object, key);
                 break;
             case 'number':
-                doc.setIntegerForKey(item, key);
+                if (this.numberIs64Bit(item)) {
+                    if (this.numberHasDecimals(item)) {
+                        doc.setDoubleForKey(item, key);
+                    } else {
+                        doc.setLongLongForKey(item, key);
+                    }
+                } else {
+                    if (this.numberHasDecimals(item)) {
+                        doc.setFloatForKey(item, key);
+                    } else {
+                        doc.setIntegerForKey(item, key);
+                    }
+                }
                 break;
             case 'boolean':
                 doc.setBooleanForKey(item, key);
@@ -195,6 +231,14 @@ export class Couchbase extends Common {
             return obj;
         }
         return null;
+    }
+
+    numberHasDecimals(item: number) {
+        return !(item % 1 === 0);
+    }
+
+    numberIs64Bit(item: number) {
+        return item < -Math.pow(2, 31) + 1 || item > Math.pow(2, 31) - 1;
     }
 
     private deserialize(data: any) {


### PR DESCRIPTION
This plugin is not able to store JS numbers that have decimals. This change fixes it and also adds proper long/float/double support by checking the number size and whether it has decimals.