### PR TITLE
Add missing float in number support

### DIFF
--- a/src/couchbase-plugin.android.ts
+++ b/src/couchbase-plugin.android.ts
@@ -86,6 +86,7 @@ export class Couchbase extends Common {
             case 'java.lang.Long':
             case 'java.lang.Double':
             case 'java.lang.Short':
+            case 'java.lang.Float':
                 return Number(data);
             case 'com.couchbase.lite.Dictionary':
                 const keys = data.getKeys();


### PR DESCRIPTION
I just noticed a minor issue in the just merged number support. The deserialize method for Android did not mention Float yet.