### PR TITLE
Change date methods to fix crash on Android API's < 24

### DIFF
--- a/src/couchbase-plugin.android.ts
+++ b/src/couchbase-plugin.android.ts
@@ -177,7 +177,7 @@ export class Couchbase extends Common {
 
     private fromISO8601UTC(date: string) {
         const dateFormat = new java.text.SimpleDateFormat(
-            'yyyy-MM-dd\'T\'HH:mm:ss.SSSXXX'
+            'yyyy-MM-dd\'T\'HH:mm:ss.SSS'
         );
         const tz = java.util.TimeZone.getTimeZone('UTC');
         dateFormat.setTimeZone(tz);
@@ -186,7 +186,7 @@ export class Couchbase extends Common {
 
     private toISO8601UTC(date: Date) {
         const dateFormat = new java.text.SimpleDateFormat(
-            'yyyy-MM-dd\'T\'HH:mm:ss.SSSXXX'
+            'yyyy-MM-dd\'T\'HH:mm:ss.SSS'
         );
         const tz = java.util.TimeZone.getTimeZone('UTC');
         dateFormat.setTimeZone(tz);


### PR DESCRIPTION
Change date methods to use the pattern "yyyy-MM-dd'T'HH:mm:ss.SSS" instead of "yyyy-MM-dd'T'HH:mm:ss.SSSXXX" as the latter is not supported on Android API's < 24 (Nougat). Timezone parsing is not required as the date string passed into fromISO8601UTC() are coming from toISOString(), and thus always having zero UTC offset (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).

This fixes the crash that occurs when trying to save / load date objects on older versions of Android.

```
I/JS      (11948): Error: java.lang.IllegalArgumentException: Unknown pattern character 'X'
I/JS      (11948):     java.text.SimpleDateFormat.validatePatternCharacter(SimpleDateFormat.java:314)
I/JS      (11948):     java.text.SimpleDateFormat.validatePattern(SimpleDateFormat.java:303)
I/JS      (11948):     java.text.SimpleDateFormat.<init>(SimpleDateFormat.java:356)
I/JS      (11948):     java.text.SimpleDateFormat.<init>(SimpleDateFormat.java:249)
I/JS      (11948):     com.tns.Runtime.callJSMethodNative(Native Method)
I/JS      (11948):     com.tns.Runtime.dispatchCallJSMethodNative(Runtime.java:1203)
I/JS      (11948):     com.tns.Runtime.callJSMethodImpl(Runtime.java:1083)
I/JS      (11948):     com.tns.Runtime.callJSMethod(Runtime.java:1070)
I/JS      (11948):     com.tns.Runtime.callJSMethod(Runtime.java:1050)
I/JS      (11948):     com.tns.Runtime.callJSMethod(Runtime.java:1042)
```
