### PR TITLE
fix: support null values

### DIFF
--- a/src/couchbase-plugin.android.ts
+++ b/src/couchbase-plugin.android.ts
@@ -213,8 +213,9 @@ export class Couchbase extends Common {
         }
     }
 
-    private serializeObject(item, object, key) {
+    private serializeObject(item: any, object: com.couchbase.lite.MutableDictionary, key: string) {
         if (item === null) {
+            object.setValue(key, null);
             return;
         }
 
@@ -264,8 +265,9 @@ export class Couchbase extends Common {
         }
     }
 
-    private serializeArray(item, array: any) {
+    private serializeArray(item: any, array: com.couchbase.lite.MutableArray) {
         if (item === null) {
+            array.addValue(null);
             return;
         }
 
@@ -315,8 +317,9 @@ export class Couchbase extends Common {
         }
     }
 
-    private serialize(item, doc: any, key) {
+    private serialize(item: any, doc: com.couchbase.lite.MutableDocument, key: string) {
         if (item === null) {
+            doc.setValue(key, null);
             return;
         }
 

--- a/src/couchbase-plugin.ios.ts
+++ b/src/couchbase-plugin.ios.ts
@@ -45,7 +45,7 @@ export class Couchbase extends Common {
     }
 
     createDocument(data: Object, documentId?: string) {
-        let doc;
+        let doc: CBLMutableDocument;
         if (documentId) {
             doc = CBLMutableDocument.alloc().initWithID(documentId);
         } else {
@@ -106,8 +106,9 @@ export class Couchbase extends Common {
         return dateFormatter.dateFromString(date);
     }
 
-    private serializeObject(item, object: any, key) {
+    private serializeObject(item: any, object: CBLMutableDictionary, key: string) {
         if (item === null) {
+            object.setValueForKey(null, key);
             return;
         }
 
@@ -157,8 +158,9 @@ export class Couchbase extends Common {
         }
     }
 
-    private serializeArray(item, array: any) {
+    private serializeArray(item: any, array: CBLMutableArray) {
         if (item === null) {
+            array.addValue(null);
             return;
         }
 
@@ -208,8 +210,9 @@ export class Couchbase extends Common {
         }
     }
 
-    private serialize(item, doc: any, key) {
+    private serialize(item: any, doc: CBLMutableDocument, key: string) {
         if (item === null) {
+            doc.setValueForKey(null, key);
             return;
         }
 

--- a/src/couchbase-plugin.ios.ts
+++ b/src/couchbase-plugin.ios.ts
@@ -332,7 +332,7 @@ export class Couchbase extends Common {
         const keys = Object.keys(data);
         for (let key of keys) {
             const item = data[key];
-            newDoc.setValueForKey(item, key);
+            this.serialize(item, newDoc, key);
         }
         this.ios.saveDocumentError(newDoc);
     }


### PR DESCRIPTION
Keys with the value NULL are no longer removed from the objects or arrays.
Null values are persisted so that the objects before and after they are stored in the database are exactly the same.

## What is the current behavior?
currently, keys with a value of null are not persisted to database and removed from the object

## What is the new behavior?
keys having a valule of null are also persisted and after a DB read, the object has all keys and values like before