### PR TITLE
fix(): non-string selection

### DIFF
--- a/src/couchbase-plugin.android.ts
+++ b/src/couchbase-plugin.android.ts
@@ -550,7 +550,9 @@ export class Couchbase extends Common {
     query(query: Query = {select: [QueryMeta.ALL, QueryMeta.ID]}) {
         const items = [];
         let select = [];
+        let isAll = false;
         if (!query.select || query.select.length === 0) {
+            isAll = true;
             select.push(com.couchbase.lite.SelectResult.all());
             select.push(
                 com.couchbase.lite.SelectResult.expression(com.couchbase.lite.Meta.id)
@@ -564,6 +566,7 @@ export class Couchbase extends Common {
                         )
                     );
                 } else if (item === QueryMeta.ALL) {
+                    isAll = true;
                     select.push(com.couchbase.lite.SelectResult.all());
                 } else {
                     select.push(com.couchbase.lite.SelectResult.property(item));
@@ -649,10 +652,10 @@ export class Couchbase extends Common {
             for (let keyId = 0; keyId < keysSize; keyId++) {
                 const key = keys.get(keyId);
                 const nativeItem = item.getValue(key);
-                if (typeof nativeItem === 'string') {
-                    obj[key] = nativeItem;
-                } else if (
+                if (
+                    isAll &&
                     nativeItem &&
+                    nativeItem.getClass &&
                     nativeItem.getClass() &&
                     nativeItem.getClass().getName() === 'com.couchbase.lite.Dictionary'
                 ) {
@@ -662,6 +665,8 @@ export class Couchbase extends Common {
                         const cblKey = cblKeys.get(cblKeysId);
                         obj[cblKey] = this.deserialize(nativeItem.getValue(cblKey));
                     }
+                } else {
+                    obj[key] = this.deserialize(nativeItem);
                 }
             }
             items.push(obj);

--- a/src/couchbase-plugin.ios.ts
+++ b/src/couchbase-plugin.ios.ts
@@ -552,7 +552,9 @@ export class Couchbase extends Common {
         let orderBy = null;
         let limit = null;
         let having = null;
+        let isAll = false;
         if (!query.select || query.select.length === 0) {
+            isAll = true;
             select.push(CBLQuerySelectResult.all());
             select.push(CBLQuerySelectResult.expression(CBLQueryMeta.id()));
         } else {
@@ -560,6 +562,7 @@ export class Couchbase extends Common {
                 if (item === QueryMeta.ID) {
                     select.push(CBLQuerySelectResult.expression(CBLQueryMeta.id()));
                 } else if (item === QueryMeta.ALL) {
+                    isAll = true;
                     select.push(CBLQuerySelectResult.all());
                 } else {
                     select.push(CBLQueryExpression.property(item));
@@ -642,15 +645,15 @@ export class Couchbase extends Common {
             for (let keyId = 0; keyId < keysSize; keyId++) {
                 const key = keys.objectAtIndex(keyId);
                 const nativeItem = item.valueForKey(key);
-                if (typeof nativeItem === 'string') {
-                    obj[key] = nativeItem;
-                } else if (types.getClass(nativeItem) === 'CBLDictionary') {
+                if (isAll && types.getClass(nativeItem) === 'CBLDictionary') {
                     const cblKeys = nativeItem.keys;
                     const cblKeysSize = cblKeys.count;
                     for (let cblKeysId = 0; cblKeysId < cblKeysSize; cblKeysId++) {
                         const cblKey = cblKeys.objectAtIndex(cblKeysId);
                         obj[cblKey] = this.deserialize(nativeItem.valueForKey(cblKey));
                     }
+                } else {
+                    obj[key] = this.deserialize(nativeItem);
                 }
             }
             items.push(obj);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
If you have a property in the `select` part of a query which type is not a string, it is not returned in the results. The query works correctly if you leave the `select` as empty (i.e. return all properties)

## What is the new behavior?
Correctly returns properties which type is not a string when they are listed in the `select` of a query. 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

