### PR TITLE
correcting the implementation for like queries. 

### DIFF
--- a/src/couchbase-plugin.android.ts
+++ b/src/couchbase-plugin.android.ts
@@ -515,7 +515,7 @@ export class Couchbase extends Common {
                 break;
             case 'like':
                 nativeQuery = com.couchbase.lite.Function.lower(
-                    item.property
+                    com.couchbase.lite.Expression.property(item.property)
                 ).like(this.serializeExpression(item.value));
                 break;
             case 'modulo':

--- a/src/couchbase-plugin.ios.ts
+++ b/src/couchbase-plugin.ios.ts
@@ -523,7 +523,7 @@ export class Couchbase extends Common {
                 ).lessThanOrEqualTo(this.serializeExpression(item.value));
                 break;
             case 'like':
-                nativeQuery = CBLQueryFunction.lower(item.property).like(
+                nativeQuery = CBLQueryFunction.lower(CBLQueryExpression.property(item.property)).like(
                     this.serializeExpression(item.value)
                 );
                 break;


### PR DESCRIPTION
Lower function takes an expression as parameter not a string..

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

